### PR TITLE
Remove target file before writing new value

### DIFF
--- a/write-scale-value.sh
+++ b/write-scale-value.sh
@@ -12,6 +12,7 @@ do
 
 	# Read scale result and write change to file
 	RESULT="$(/home/pi/scale/usbscale/usbscale)"
+	rm ${TARGET_FILE}
 	echo ${RESULT} > ${TARGET_FILE}
 	echo "Current weight: ${RESULT}"
 done


### PR DESCRIPTION
node-scale-reader doesn't support updates in the previous way. So the file needs to be removed first.
